### PR TITLE
fix: flow measure statuses not being delivered

### DIFF
--- a/src/flowmeasure/FlowMeasureStatusUpdates.cpp
+++ b/src/flowmeasure/FlowMeasureStatusUpdates.cpp
@@ -26,7 +26,7 @@ namespace ECFMP::FlowMeasure {
             if (!canonicalFlowMeasures.contains(canonicalInformation.Identifier())) {
                 canonicalFlowMeasures[canonicalInformation.Identifier()] = measure;
                 BroadcastStatusUpdate(measure);
-                return;
+                continue;
             }
 
             // Switch the measure we have stored out for the new one


### PR DESCRIPTION
Flow measure statuses weren't being delivered straight away. This was due to an errant return that should have been a continue, which shortcircuited the function if new measures show up.

Fixes #15 